### PR TITLE
New dealAll method for dealing all cards

### DIFF
--- a/src/main/java/models/Game.java
+++ b/src/main/java/models/Game.java
@@ -22,6 +22,15 @@ public class Game {
         }
     }
 
+    public void dealAll() {
+        while (true) {
+            for (int i = 0; i < 4; i++) {
+                Card c = deck.cards.get(0);
+                columns.get(i).cards.add(c);
+            }
+        }
+    }
+
     //customDeal to setup game for testing purposes (i.e. shuffled cards are random and hard to test)
     public void customDeal(int c1, int c2, int c3, int c4) {
         columns.get(0).cards.add(deck.cards.get(c1));


### PR DESCRIPTION
This PR adds a new `Game.java::dealAll()` method that allows the game to deal all cards instead of only dealing four at a time.